### PR TITLE
Document another case of GHC-53786

### DIFF
--- a/message-index/messages/GHC-53786/case-expr-in-do-block/after/CaseExprInDoBlock.hs
+++ b/message-index/messages/GHC-53786/case-expr-in-do-block/after/CaseExprInDoBlock.hs
@@ -1,0 +1,8 @@
+module CaseExprInDoBlock where
+
+x :: [a]
+x = do
+  case () of
+    () -> do
+      a <- []
+      pure a

--- a/message-index/messages/GHC-53786/case-expr-in-do-block/before/CaseExprInDoBlock.hs
+++ b/message-index/messages/GHC-53786/case-expr-in-do-block/before/CaseExprInDoBlock.hs
@@ -1,0 +1,8 @@
+module CaseExprInDoBlock where
+
+x :: [a]
+x = do
+  case () of
+    () ->
+      a <- []
+      pure a

--- a/message-index/messages/GHC-53786/case-expr-in-do-block/index.md
+++ b/message-index/messages/GHC-53786/case-expr-in-do-block/index.md
@@ -2,7 +2,9 @@
 title: Case expression in do-block
 ---
 
-The expression in one branch of the case expression is a do-block that's missing a `do`; the whole case-expression is interpreted as LHS of a bind in the top-level do-block. See also: https://gitlab.haskell.org/ghc/ghc/-/issues/984
+The expression in one branch of the case expression is a `do`-block that's missing a `do`. This triggers a corner case in the grammar of Haskell, and the `case`-expression is interpreted as the pattern part of a bind statement in the top-level `do`-block. 
+
+More details are available at https://gitlab.haskell.org/ghc/ghc/-/issues/984
 
 ## Error Message
 

--- a/message-index/messages/GHC-53786/case-expr-in-do-block/index.md
+++ b/message-index/messages/GHC-53786/case-expr-in-do-block/index.md
@@ -1,0 +1,16 @@
+---
+title: Case expression in do-block
+---
+
+The expression in one branch of the case expression is a do-block that's missing a `do`; the whole case-expression is interpreted as LHS of a bind in the top-level do-block. See also: https://gitlab.haskell.org/ghc/ghc/-/issues/984
+
+## Error Message
+
+```
+CaseExprInDoBlock.hs:5:3: error: [GHC-53786]
+    (case ... of ...)-syntax in pattern
+  |
+5 |   case () of
+  |   ^^^^^^^^^^...
+
+```


### PR DESCRIPTION
A case-expression inside a do-block whose branch expression is missing a `do` parses unintuitively, resulting in a confusing GHC-53786. It seems worthwhile to document  this explicitly.