### PR TITLE
Add guidance about GHCup's pre-release channel

### DIFF
--- a/message-index/messages/GHCup-00010/index.md
+++ b/message-index/messages/GHCup-00010/index.md
@@ -64,4 +64,4 @@ Other reasons you might get this error:
 
 * The version of the tool you specified doesn't exist at all, e.g. `ghcup install ghc blah`.
 * The version of the tool you specified wasn't added to GHCup yet, but will likely be added soon. Please [raise an issue here](https://github.com/haskell/ghcup-metadata/issues) and make sure to update ghcup's internal list of available tools with `ghcup upgrade`.
-
+* The version of the tool you specified was a pre-release, like an alpha or release candidate. Add [a release channel](https://www.haskell.org/ghcup/guide/#pre-release-channels) to make it available. For example: `ghcup config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml`.


### PR DESCRIPTION
I ran into this while trying to install ghc GHC 9.6.1-alpha1 using GHCup. The GHCup-000100 page already contains enough information to piece this together, but I figured it was worth an explicit callout. 