### PR TITLE
Update index.html

### DIFF
--- a/message-index/index.html
+++ b/message-index/index.html
@@ -7,7 +7,7 @@ title: The Haskell Error Index
 <p>
   This site describes the various messages that can be returned by Haskell-related tools, including both errors and warnings.
   For example GHC, the most-commonly-used Haskell implementation, started emiting a code with the format <code>[GHC-12345]</code> for some of its
-  messages since version 9.6.1.
+  messages in version 9.6.1.
   These codes can be looked up below for further information.
 </p>
 

--- a/message-index/index.html
+++ b/message-index/index.html
@@ -6,7 +6,7 @@ title: The Haskell Error Index
 
 <p>
   This site describes the various messages that can be returned by Haskell-related tools, including both errors and warnings.
-  For example GHC, the most-commonly-used Haskell implementation, started emiting a code with the format <code>[GHC-12345]</code> for some of its
+  For example GHC, the most-commonly-used Haskell implementation, started emiting a code with the format <code>[GHC-12345]</code> for its
   messages in version 9.6.1.
   These codes can be looked up below for further information.
 </p>

--- a/message-index/index.html
+++ b/message-index/index.html
@@ -5,10 +5,10 @@ title: The Haskell Error Index
 <h2>Welcome</h2>
 
 <p>
-  This site describes the various messages that can be returned by
-  GHC, the most-commonly-used Haskell implementation, including both errors and warnings. Beginning with version
-  9.6.1, GHC emits a code with the format <code>[GHC-12345]</code> for each
-  message. These codes can be looked up below for further information.
+  This site describes the various messages that can be returned by Haskell-related tools, including both errors and warnings.
+  For example GHC, the most-commonly-used Haskell implementation, started emiting a code with the format <code>[GHC-12345]</code> for some of its
+  messages since version 9.6.1.
+  These codes can be looked up below for further information.
 </p>
 
 <p>


### PR DESCRIPTION
- mention only GHC as an example since some `ghcup` errors are indexed too
- soften the wording about GHC returning codes for its messages (it's still a work in progress)