### PR TITLE
Implement setting query from URL

### DIFF
--- a/message-index/index.html
+++ b/message-index/index.html
@@ -56,5 +56,20 @@ var input = document.querySelector('.single_flt');
 if (input) {
   input.setAttribute("placeholder", "🔍 Type here to filter ...");
   input.focus();
+  
+  //Autofill the search from the URL 
+  let url = new URL(document.location.href);
+  let query = url.searchParams.get('q');
+  if(query !== null)
+  {
+    input.setAttribute('value',query)
+    //Move cursor to end
+    input.setSelectionRange(query.length,query.length);
+
+    //Make sure that the list gets filtered as if the query had been typed manually
+    input.dispatchEvent(new KeyboardEvent('keyup'));
+
+  }
 }
+
 </script>


### PR DESCRIPTION
Implements the feature requested in issue #350. The site now auto-fills the contents of the search box with whatever is given in the query parameter `?q=...`, if it is given.