### PR TITLE
Don't render 'Enabled by:' for flags which are not part of any flag group

### DIFF
--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -274,7 +274,9 @@ flagSetFields =
           _ -> noResult "",
       field "flag_group" $ \_me -> do
         flagInfo >>= \case
-          Just (_, g) -> return $ unwords g
+          -- Don't render flag_group field for flags which are not member of any flag group (like -Wall)
+          Just (_, []) -> noResult ""
+          Just (_, groups) -> return $ unwords groups
           Nothing -> return ""
     ]
 

--- a/message-index/templates/message.html
+++ b/message-index/templates/message.html
@@ -4,7 +4,9 @@ $if(flag)$
   $if(on_by_default)$
   <i>Enabled by default</i>
   $else$
-  <i>Enabled by: <code>$flag_group$</code></i>
+      $if(flag_group)$
+      <i>Enabled by: <code>$flag_group$</code></i>
+      $endif$
   $endif$
 </p>
 $endif$


### PR DESCRIPTION
An attempt to fix https://github.com/haskellfoundation/error-message-index/issues/389

TBH I'm not really friends with hakyll, so I've no idea if this "the hakyll way" to do this (would be happy to learn how to do this in more elegant way).

I just checked it does what I intended by rebuilding the site locally checking the items with empty "Enabled by:" are gone.

![Screenshot from 2023-03-06 14-42-41](https://user-images.githubusercontent.com/2716069/223127479-e27be06b-afb5-4d43-85b5-c43a827ecfb1.png)
