### PR TITLE
Update the caching logic for the deploy action. 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,16 +14,27 @@ jobs:
     strategy:
       matrix:
         target: [haskellorg, githubpages]
+        ghc: ["9.2.5"]
+        cabal: ["3.10.1"]
 
     steps:
-    - name: Install GHC 9.2.5
-      run: ghcup install ghc 9.2.5
-
-    - name: Select GHC 9.2.5
-      run: ghcup set ghc 9.2.5
-
     - name: Check out repo
       uses: actions/checkout@v3
+
+    - name: Install Haskell Toolchain
+      uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Configure the build plan
+      working-directory: message-index
+      run: |
+        cabal update
+        cabal build --dry-run
+      # cabal build --dry-run creates dist-newstyle/cache/plan.json
+      # Keep a watch on this `cabal-3.9 build --dry-run` bug:
+      # https://github.com/haskell/cabal/issues/8706
       
     - name: Read the Cabal cache
       uses: actions/cache@v3
@@ -31,12 +42,11 @@ jobs:
         path: |
           ~/.cabal/store
           message-index/dist-newstyle
-        key: cabal-cache-0-${{ hashFiles('message-index/message-index.cabal') }}
+        key: |
+          cabal-cache-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-${{ hashFiles('**/plan.json') }}
         restore-keys: |
-          cabal-cache-0
+          cabal-cache-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-
 
-    - name: Update the Cabal index
-      run: cabal update
 
     - name: Build with Hakyll
       working-directory: message-index


### PR DESCRIPTION
The deploy action should use the same caching logic as pullrequest-ci.yml, since the content of the caches is not shared among different branches, only the caches of the default branch (main) is shared with the CI actions run on the PR branches