### PR TITLE
Make 404 friendlier

### DIFF
--- a/message-index/404.html
+++ b/message-index/404.html
@@ -8,6 +8,18 @@ title: The Haskell Error Index
 const messageRe = /^\/messages\/([A-Za-z]+-[0-9]+)/;
 if (messageRe.test(window.location.pathname)) {
   const messageNum = window.location.pathname.match(messageRe)[1];
-  document.getElementById("documentation-pointer").innerHTML = "Message <code>" + messageNum + "</code> is currently undocumented. You can help out by <a href=\"https://github.com/haskellfoundation/error-message-index/issues?q=is%3Aissue+is%3Aopen+" + messageNum + "\">opening or commenting on an issue</a> or <a href=\"https://github.com/haskellfoundation/error-message-index/blob/main/CONTRIBUTING.md\">contributing documentation</a>."
+
+  const ghcSince = "9.6.1";
+  const otherSince = "VERSION%20IN%20WHICH%20THE%20ERROR%20CODE%20WAS%20INTRODUCED";
+  const since = messageNum.substring(0, 4) == "GHC-" ? ghcSince : otherSince;
+  const defaultContents = "---%0Atitle%3A%20SHORT%20TITLE%0Asummary%3A%20ONE%20SENTENCE%20SUMMARY%0Aintroduced%3A%20" + since + "%0Aseverity%3A%20CHOOSE%20ONE%3A%20warning%20error%0A---%0A%0APlease%20describe%20the%20meaning%20of%20the%20error%20here%2C%20formatted%20in%20Markdown.";
+  const contribURL = "https://github.com/haskellfoundation/error-message-index/new/main/message-index/messages/" + messageNum + "/new?filename=index.md&value=" + defaultContents;
+
+  const firstPara = "<p>Message <code>" + messageNum + "</code> is not yet documented here.</p>";
+  const secondPara "<p>You can help out by documenting it. There are two ways to get started:</p>";
+  const list = "<ul><li><a href=\"" + contribURL + "\">Submit documentation directly through GitHub's online editor</a></li><li><a href=\"https://github.com/haskellfoundation/error-message-index/blob/main/CONTRIBUTING.md\">Add documentation or examples on your own computer</a> and send a pull request</li></ul>";
+  const thirdPara = "<p>All contributions are reviewed. We welcome contributions from new Haskellers and non-expert users of English - we'll work together to create high-quality documentation.";
+
+  document.getElementById("documentation-pointer").innerHTML = firstPara + secondPara + list + thirdPara;
 }
 </script>

--- a/message-index/404.html
+++ b/message-index/404.html
@@ -13,7 +13,7 @@ if (messageRe.test(window.location.pathname)) {
   const otherSince = "VERSION%20IN%20WHICH%20THE%20ERROR%20CODE%20WAS%20INTRODUCED";
   const since = messageNum.substring(0, 4) == "GHC-" ? ghcSince : otherSince;
   const defaultContents = "---%0Atitle%3A%20SHORT%20TITLE%0Asummary%3A%20ONE%20SENTENCE%20SUMMARY%0Aintroduced%3A%20" + since + "%0Aseverity%3A%20CHOOSE%20ONE%3A%20warning%20error%0A---%0A%0APlease%20describe%20the%20meaning%20of%20the%20error%20here%2C%20formatted%20in%20Markdown.";
-  const contribURL = "https://github.com/haskellfoundation/error-message-index/new/main/message-index/messages/" + messageNum + "/new?filename=index.md&value=" + defaultContents;
+  const contribURL = "https://github.com/haskellfoundation/error-message-index/new/main/message-index/messages/" + messageNum + "/?filename=index.md&value=" + defaultContents;
 
   const firstPara = "<p>Message <code>" + messageNum + "</code> is not yet documented here.</p>";
   const secondPara "<p>You can help out by documenting it. There are two ways to get started:</p>";


### PR DESCRIPTION
Update the 404 page to use some [undocumented features](https://github.com/isaacs/github/issues/1527) of the GitHub "create page" feature to automatically provide the right filename and a template.

It seems that the "create page" query strings have worked this way for at least a couple of years now, and it'll be easy enough to tweak the page again if it changes.