### PR TITLE
Fix permission and paths for HLint action.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -18,6 +18,9 @@ jobs:
   hlint:
     name: HLint
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to GitHub code scanning.
+      security-events: write
     steps:
     - uses: actions/checkout@v3
     - name: Check site.hs with hlint

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -3,12 +3,12 @@ name: HLint
 on:
   push:
     paths:
-      - '**/site.hs'
+      - 'message-index/site.hs'
     branches:
       - main
   pull_request:
     paths:
-      - '**/site.hs'
+      - 'message-index/site.hs'
     types:
       - opened
       - synchronize
@@ -24,5 +24,5 @@ jobs:
       uses: haskell-actions/hlint-scan@v1
       with:
         path: |
-          **/site.hs
-        hints: message_index/.hlint.yml
+          message-index/site.hs
+        hints: message-index/.hlint.yml


### PR DESCRIPTION
* GitHub requires the write permission for `security-events` to upload analysis results.  See https://docs.github.com/en/rest/code-scanning#upload-an-analysis-as-sarif-data

* Paths are passed to HLint as is, which does not use them as file patterns.  The paths were changed to a specific path instead of a file pattern for consistency.  In addition, there was a typo in a path.

To see the HLint action in action in a pull request, see https://github.com/chungyc/error-message-index/pull/2.