### PR TITLE
Do not trigger HLint on pull requests.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -6,13 +6,6 @@ on:
       - 'message-index/site.hs'
     branches:
       - main
-  pull_request:
-    paths:
-      - 'message-index/site.hs'
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 jobs:
   hlint:


### PR DESCRIPTION
It turns out that the HLint code scanning action is not able to work with pull requests from forked repositories because GitHub prevents it from getting the permission it needs to do so.  It will still work on pull requests local to the repository, but triggering on a push is enough to have this working as well.

See https://github.com/haskell-actions/hlint-scan/issues/48 for more details.