### PR TITLE
Added create-message-template.yml Github CI file

### DIFF
--- a/.github/workflows/create-message-template.yml
+++ b/.github/workflows/create-message-template.yml
@@ -1,0 +1,26 @@
+name: Create-Message-Template
+
+on:
+  push:
+    paths:
+      - '**/create-message-template.hs'
+      - 'test/'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '**/create-message-template.hs'
+      - 'test/'
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  create-message-template:
+    name: Testing create-message-template.hs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
+    - run: test/create-message-template/test.sh


### PR DESCRIPTION
This adds the CI configuration for the test which was introduced in #409 .
I have tested these changes on this PR branch with two commits which I have then reverted.

Successful run: https://github.com/haskellfoundation/error-message-index/actions/runs/5121559267
Failing run: https://github.com/haskellfoundation/error-message-index/actions/runs/5121581346

Since this PR is pretty trivial, I will merge it on my own @david-christiansen 