### PR TITLE
Scan HLint on pull requests.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -7,6 +7,12 @@ on:
       - 'message-index/create-message-template.hs'
     branches:
       - main
+  pull_request:
+    paths:
+      - 'message-index/site.hs'
+      - 'message-index/create-message-template.hs'
+    branches:
+      - main
 
 jobs:
   hlint:


### PR DESCRIPTION
According to https://github.com/orgs/community/discussions/54013, uploading scan results for a pull request no longer requires write permission against the destination repository. Re-enable HLint code scanning for pull requests, which will also show any warnings and corresponding code in the pull request itself.

A sample pull request is at https://github.com/haskellfoundation/error-message-index/pull/414.