### PR TITLE
Allow pandoc-types 1.23

### DIFF
--- a/message-index/message-index.cabal
+++ b/message-index/message-index.cabal
@@ -12,7 +12,7 @@ executable site
                   , microlens ^>= 0.4.12
                   , binary ^>= 0.8.8
                   , aeson ^>= 2.0.3 || ^>= 2.1
-                  , pandoc-types ^>= 1.22
+                  , pandoc-types ^>= 1.22 || ^>= 1.23
                   , containers ^>= 0.6
                   , text ^>= 1.2 || ^>= 2.0
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
Apparently Cabal in CI could do the version bump from #417, but not in my local setup? So this update seems to fix it, it's probably downstream from Hakyll using a newer Pandoc. 