### PR TITLE
Explain GHC-39999 arising from OverloadedRecordDot

### DIFF
--- a/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/after/Main.hs
+++ b/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/after/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import DataType (MyData(foo))
+
+getFoo :: MyData -> Int
+getFoo x = x.foo

--- a/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/before/Main.hs
+++ b/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/before/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import DataType (MyData)
+
+getFoo :: MyData -> Int
+getFoo x = x.foo

--- a/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/index.md
+++ b/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/index.md
@@ -1,0 +1,33 @@
+---
+title: A usage of `x.foo` with the field `foo` not being in scape
+---
+
+## Error message
+
+```
+src/Main.hs:6:12: error: [GHC-39999]
+    • No instance for ‘GHC.Records.HasField "foo" MyData Int’
+        arising from selecting the field ‘foo’
+      Perhaps you want to add ‘foo’ to the import list in the import of
+      ‘DataType’ (src/Main.hs:3:1-24).
+    • In the expression: x.foo
+      In an equation for ‘getFoo’: getFoo x = x.foo
+  |
+6 | getFoo x = x.foo
+  |
+```
+
+## Explanation
+
+This error arises when using the `OverloadedRecordDot` extension.
+Given a module exporting a record:
+
+```haskell
+module DataType where
+
+data MyData = MyData { foo :: Int, bar :: String }
+```
+
+When `MyData` is imported into a module without also importing the fields, attempting to access fields using `OverloadedRecordDot` will result in an error.
+
+Adding the field to the import list will resolve the issue.


### PR DESCRIPTION
This adds an explanation for the instance resolution failure that arises when using overloaded record dot and accessing a field of a known type when the field is not in scope