### PR TITLE
document GHC-55666

### DIFF
--- a/message-index/messages/GHC-55666/example/after/Bang_on_unlifted_type.hs
+++ b/message-index/messages/GHC-55666/example/after/Bang_on_unlifted_type.hs
@@ -1,0 +1,5 @@
+module Bang_on_unlifted_type where
+
+import GHC.Base (Int#)
+
+data T = MkT Int#

--- a/message-index/messages/GHC-55666/example/before/Bang_on_unlifted_type.hs
+++ b/message-index/messages/GHC-55666/example/before/Bang_on_unlifted_type.hs
@@ -1,0 +1,5 @@
+module Bang_on_unlifted_type where
+
+import GHC.Base (Int#)
+
+data T = MkT !Int#

--- a/message-index/messages/GHC-55666/example/index.md
+++ b/message-index/messages/GHC-55666/example/index.md
@@ -1,0 +1,3 @@
+---
+title: Bang (!) on unlifted type
+---

--- a/message-index/messages/GHC-55666/index.md
+++ b/message-index/messages/GHC-55666/index.md
@@ -1,0 +1,16 @@
+---
+title: Strictness annotation on unlifted type
+summary: Using a strictness annotation (bang) on an unlifted type is redudant as unlifted values are strict by definition
+severity: warning
+flag: -Wredundant-strictness-flags
+introduced: GHC 9.6.1
+---
+
+A strictness annotation (also called a bang: `!`) can be used to denote that a type should not be evaluated lazily.
+In some cases this can lead to faster code because fewer heap allocation are required.
+
+However, unlifted types like `Int#` are strict by definition because they are a value,
+not a pointer to a potentially unevaluated value (thunk).
+
+Therefore, adding strictness annotations to unlifted types or fields of such types are redudant.
+They should be omitted to prevent confusion.


### PR DESCRIPTION
The warning is not emitted by default, hence I first thought to have found a bug in GHC. Luckily that was not the case but I my inexperienced fingers still yearned for a contribution so I thought I'd add the warning to the error index instead :)