### PR TITLE
Documenting two examples for `83865`; Adds `order` field to example headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,10 +170,15 @@ The fields in the metadata block should be:
 ### Example Descriptions
 
 Example descriptions are written in Markdown with Pandoc-style
-metadata, just like message descriptions. They have only the `title`
-field. All `.hs` files are shown in the list of files for the
+metadata, just like message descriptions. They have the obligatory `title`
+and optional `order` fields. All `.hs` files are shown in the list of files for the
 example. The `index.md` file should explain how the files illustrate
 the message.
+
+Examples are ordered according to their `order` field. Examples
+with no explicit `order` are shown last and examples with the same
+`order` will be shown in an unspecified order with respect to each other,
+but will appear before examples with a greater order.
 
 ## Reference: Technology choices
 

--- a/message-index/messages/GHC-83865/index.md
+++ b/message-index/messages/GHC-83865/index.md
@@ -1,0 +1,15 @@
+---
+title: Type Mismatch
+summary: You provided a value of a given type, whereas GHC expected a different type.
+severity: error
+introduced: 9.6.1
+---
+
+GHC expected one type, but was given another. Unlike dynamically-typed programming languages,
+type signatures in Haskell are like a contract between the programmer and the compiler.
+In its simplest form, when you call a function `f` with type `a -> b`, with some argument `x`,
+the compiler will check whether `x` has type `a` and if that is not the case, it will trigger
+the type mismatch error. This case is illustrated by the `terms` example, below.
+
+Type mismatch errors are quite general, however, so you will still encounter them
+in many other situations.

--- a/message-index/messages/GHC-83865/terms/after/Terms.hs
+++ b/message-index/messages/GHC-83865/terms/after/Terms.hs
@@ -1,7 +1,4 @@
-module Simple where
-
 inc :: Int -> Int
 inc i = i + 1
 
 two = inc 1
-

--- a/message-index/messages/GHC-83865/terms/after/Terms.hs
+++ b/message-index/messages/GHC-83865/terms/after/Terms.hs
@@ -1,0 +1,7 @@
+module Simple where
+
+inc :: Int -> Int
+inc i = i + 1
+
+two = inc 1
+

--- a/message-index/messages/GHC-83865/terms/before/Terms.hs
+++ b/message-index/messages/GHC-83865/terms/before/Terms.hs
@@ -1,7 +1,4 @@
-module Simple where
-
 inc :: Int -> Int
 inc i = i + 1
 
 two = inc "x"
-

--- a/message-index/messages/GHC-83865/terms/before/Terms.hs
+++ b/message-index/messages/GHC-83865/terms/before/Terms.hs
@@ -1,0 +1,7 @@
+module Simple where
+
+inc :: Int -> Int
+inc i = i + 1
+
+two = inc "x"
+

--- a/message-index/messages/GHC-83865/terms/index.md
+++ b/message-index/messages/GHC-83865/terms/index.md
@@ -1,0 +1,15 @@
+---
+title: Values of Different Types
+---
+
+Function `inc` has type `Int -> Int`, hence it expects an argument
+of type `Int`; yet, on the definition of `two` it was called with
+an argument of type `String`.
+
+If you ever need to know the type of something, you can ask for it in `ghci`
+and ask for it with `:type` (or its shorthand `:t`):
+
+```
+ghci> :t "x"
+"x" :: String
+```

--- a/message-index/messages/GHC-83865/terms/index.md
+++ b/message-index/messages/GHC-83865/terms/index.md
@@ -8,7 +8,7 @@ of type `Int`; yet, on the definition of `two` it was called with
 an argument of type `String`.
 
 If you ever need to know the type of something, you can ask for it in `ghci`
-and ask for it with `:type` (or its shorthand `:t`):
+with the command `:type` (or its shorthand `:t`):
 
 ```
 ghci> :t "x"

--- a/message-index/messages/GHC-83865/terms/index.md
+++ b/message-index/messages/GHC-83865/terms/index.md
@@ -1,5 +1,6 @@
 ---
 title: Values of Different Types
+order: 1
 ---
 
 Function `inc` has type `Int -> Int`, hence it expects an argument

--- a/message-index/messages/GHC-83865/terms/index.md
+++ b/message-index/messages/GHC-83865/terms/index.md
@@ -1,6 +1,6 @@
 ---
 title: Values of Different Types
-order: 1
+order: 0
 ---
 
 Function `inc` has type `Int -> Int`, hence it expects an argument
@@ -13,4 +13,19 @@ and ask for it with `:type` (or its shorthand `:t`):
 ```
 ghci> :t "x"
 "x" :: String
+```
+
+## Error Message
+
+```
+Terms.hs:6:11: error: [GHC-83865]
+    • Couldn't match type ‘[Char]’ with ‘Int’
+      Expected: Int
+        Actual: String
+    • In the first argument of ‘inc’, namely ‘"x"’
+      In the expression: inc "x"
+      In an equation for ‘two’: two = inc "x"
+  |
+4 | two = inc "x"
+  |
 ```

--- a/message-index/messages/GHC-83865/type-kind-mism/after/Type.hs
+++ b/message-index/messages/GHC-83865/type-kind-mism/after/Type.hs
@@ -1,0 +1,3 @@
+isNothing :: Maybe a -> Bool
+isNothing Nothing = True
+isNothing _ = False

--- a/message-index/messages/GHC-83865/type-kind-mism/before/Type.hs
+++ b/message-index/messages/GHC-83865/type-kind-mism/before/Type.hs
@@ -1,0 +1,4 @@
+isNothing :: Maybe -> Bool
+isNothing Nothing = True
+isNothing _ = False
+

--- a/message-index/messages/GHC-83865/type-kind-mism/index.md
+++ b/message-index/messages/GHC-83865/type-kind-mism/index.md
@@ -1,0 +1,21 @@
+---
+title: Type expected, but kind received.
+---
+
+Forgetting the type parameter to `Maybe` is the culprit, but it is only caught in the
+context of the the arrow in the declaration of `isNothing`, which can be confusing.
+Recall that the arrow (`->`) in Haskell is a type constructor, it takes two types
+of *kind* `Type`, and returns a fresh type, also of kind `Type`. That is, for `x -> y`
+to make any sense, GHC needs `x` and `y` to be types of kind `Type`, which is not
+the case in this example: `Maybe` by itself has kind `Type -> Type`.
+
+If you ever need to know the kind of something, you can ask `ghci`
+with the `:kind` (or its shorthand `:k`), keeping in mind
+that `*` (pronounced "star") is a synonym for `Type`:
+
+```
+ghci> :k (->)
+(->) :: * -> * -> *
+ghci> :k Maybe
+Maybe :: * -> *
+```

--- a/message-index/messages/GHC-83865/type-kind-mism/index.md
+++ b/message-index/messages/GHC-83865/type-kind-mism/index.md
@@ -1,6 +1,6 @@
 ---
 title: Type expected, but kind received.
-order: 0
+order: 1
 ---
 
 Forgetting the type parameter to `Maybe` is the culprit, but it is only caught in the
@@ -19,4 +19,16 @@ ghci> :k (->)
 (->) :: * -> * -> *
 ghci> :k Maybe
 Maybe :: * -> *
+```
+
+## Error Message
+
+```
+Type.hs:1:14: error: [GHC-83865]
+    • Expecting one more argument to ‘Maybe’
+      Expected a type, but ‘Maybe’ has kind ‘* -> *’
+    • In the type signature: isNothing :: Maybe -> Bool
+  |
+1 | isNothing :: Maybe -> Bool
+  |
 ```

--- a/message-index/messages/GHC-83865/type-kind-mism/index.md
+++ b/message-index/messages/GHC-83865/type-kind-mism/index.md
@@ -1,5 +1,6 @@
 ---
 title: Type expected, but kind received.
+order: 0
 ---
 
 Forgetting the type parameter to `Maybe` is the culprit, but it is only caught in the

--- a/message-index/messages/GHC-83865/type-kind-mism/index.md
+++ b/message-index/messages/GHC-83865/type-kind-mism/index.md
@@ -5,7 +5,7 @@ order: 1
 
 Forgetting the type parameter to `Maybe` is the culprit, but it is only caught in the
 context of the the arrow in the declaration of `isNothing`, which can be confusing.
-Recall that the arrow (`->`) in Haskell is a type constructor, it takes two types
+The arrow (`->`) in Haskell is a _type constructor_. It takes two types
 of *kind* `Type`, and returns a fresh type, also of kind `Type`. That is, for `x -> y`
 to make any sense, GHC needs `x` and `y` to be types of kind `Type`, which is not
 the case in this example: `Maybe` by itself has kind `Type -> Type`.

--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -10,8 +10,8 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Binary (Binary)
 import Data.Data (Typeable)
 import Data.Foldable (for_)
-import Data.Functor ((<&>))
 import Data.Function (on)
+import Data.Functor ((<&>))
 import Data.List (find, isPrefixOf, lookup, nub, sort, sortBy)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -25,8 +25,6 @@ import Lens.Micro (_1, _2, _3)
 import Lens.Micro.Extras (view)
 import System.FilePath
 import Text.Pandoc.Definition (Meta (..), MetaValue (..), Pandoc (..))
-
-import Debug.Trace
 
 main :: IO ()
 main = hakyll $ do

--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -202,7 +202,7 @@ instance Ord ExampleOrder where
   compare (InGroup i) (InGroup j) = compare i j
   compare (InGroup _) Last = LT
   compare Last (InGroup _) = GT
-  compare Last Last = EQ  
+  compare Last Last = EQ
 
 getExampleOrder :: Identifier -> Compiler ExampleOrder
 getExampleOrder ident = do

--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -196,7 +196,13 @@ messageCtx :: Context String
 messageCtx = field "id" (pure . getId) <> indexlessUrlField "url"
 
 data ExampleOrder = InGroup Integer | Last
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
+
+instance Ord ExampleOrder where
+  compare (InGroup i) (InGroup j) = compare i j
+  compare (InGroup _) Last = LT
+  compare Last (InGroup _) = GT
+  compare Last Last = EQ  
 
 getExampleOrder :: Identifier -> Compiler ExampleOrder
 getExampleOrder ident = do

--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -193,6 +193,17 @@ messageTitleField = field "title" getTitle
 messageCtx :: Context String
 messageCtx = field "id" (pure . getId) <> indexlessUrlField "url"
 
+data ExampleOrder = InGroup Integer | Last
+
+getExampleOrder :: Identifier -> Compiler ExampleOrder
+getExampleOrder ident = do
+  metas <- getMetadata ident
+  let msgId = getIdentId ident
+  case KM.lookup "order" metas of
+    (Just (JSON.Number i)) -> pure $ InGroup (truncate i)
+    Just other -> fail $ "Not an integer: " ++ show other
+    Nothing -> pure Last
+
 getId :: Item a -> String
 getId item = fromMaybe "" $ getIdentId (itemIdentifier item)
 
@@ -213,6 +224,7 @@ getExamples = do
 getExampleFiles :: Compiler [Item (FilePath, Maybe (Item String), Maybe (Item String))]
 getExampleFiles = do
   me <- getUnderlying
+  error (show me)
   (id, exampleName) <- case splitDirectories $ toFilePath me of
     ["messages", id, exampleName, _mdFile] -> pure (id, exampleName)
     _ -> fail "Not processing an example"


### PR DESCRIPTION
That's a tricky error code, it shows up in many situations (https://gitlab.haskell.org/ghc/ghc/-/issues/23466), but at the same time it is one of the errors that beginners will hit the most. I attempted to document what I believe are the two situations where 83865 will appear first when someone is learning Haskell, so I tried to keep the examples almost trivially simple and the explanations short and concise. What do you folks think?

Closes #438 