### PR TITLE
Added another example of error GHC-39999

### DIFF
--- a/message-index/messages/GHC-39999/no-instance/index.md
+++ b/message-index/messages/GHC-39999/no-instance/index.md
@@ -1,5 +1,6 @@
 ---
 title: A usage of (==) on a data type which doesn‘t have an instance for Eq.
+order: 0
 ---
 
 ## Error message

--- a/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/index.md
+++ b/message-index/messages/GHC-39999/overloaded-record-dot-selector-not-in-scope/index.md
@@ -1,5 +1,6 @@
 ---
-title: A usage of `x.foo` with the field `foo` not being in scape
+title: A usage of `x.foo` with the field `foo` not being in scope
+order: 2
 ---
 
 ## Error message

--- a/message-index/messages/GHC-39999/superclass/after/Main.hs
+++ b/message-index/messages/GHC-39999/superclass/after/Main.hs
@@ -1,0 +1,9 @@
+import Data.Functor.Classes (Show1(..))
+
+newtype Foo a = Foo a
+
+instance Show a => Show (Foo a) where
+   show (Foo a) = "Foo " ++ show a
+
+instance Show1 Foo where
+  liftShowsPrec showsPrec _showList prec (Foo a) rest = "Foo " ++ showsPrec prec a rest

--- a/message-index/messages/GHC-39999/superclass/before/Main.hs
+++ b/message-index/messages/GHC-39999/superclass/before/Main.hs
@@ -1,0 +1,6 @@
+import Data.Functor.Classes (Show1(..))
+
+newtype Foo a = Foo a
+
+instance Show1 Foo where
+  liftShowsPrec showsPrec _showList prec (Foo a) rest = "Foo " ++ showsPrec prec a rest

--- a/message-index/messages/GHC-39999/superclass/index.md
+++ b/message-index/messages/GHC-39999/superclass/index.md
@@ -1,0 +1,24 @@
+---
+title: Missing superclass declaration
+---
+
+### Error message on GHC 9.6.2
+
+```
+Main.hs:5:10: error: [GHC-39999]
+    • Could not deduce ‘Show (Foo a)’
+        arising from the head of a quantified constraint
+        arising from the superclasses of an instance declaration
+      from the context: Show a
+        bound by a quantified context at Main.hs:5:10-18
+    • In the instance declaration for ‘Show1 Foo’
+  |
+5 | instance Show1 Foo where
+  |          ^^^^^^^^^
+```
+
+## Explanation
+
+The [`Show1`](https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-Functor-Classes.html#t:Show1) class has
+changed in GHC 9.6 to require a quantified superclass constraint `Show`. To fix this error, for every `instance
+Show1` declaration add a corresponding `instance Show` declaration for the same data type.

--- a/message-index/messages/GHC-39999/superclass/index.md
+++ b/message-index/messages/GHC-39999/superclass/index.md
@@ -1,5 +1,6 @@
 ---
 title: Missing superclass declaration
+order: 3
 ---
 
 ### Error message on GHC 9.6.2

--- a/message-index/messages/GHC-39999/too-polymorphic/index.md
+++ b/message-index/messages/GHC-39999/too-polymorphic/index.md
@@ -1,5 +1,6 @@
 ---
 title: A usage of `+` on a too polymorphic variable.
+order: 1
 ---
 
 ## Error message


### PR DESCRIPTION
I think this example is worth including because it's an effect of a backward incompatible change in `base`.