### PR TITLE
Fix two incorrect instances of the "introduced" field

### DIFF
--- a/message-index/messages/GHC-55666/index.md
+++ b/message-index/messages/GHC-55666/index.md
@@ -3,7 +3,7 @@ title: Strictness annotation on unlifted type
 summary: Using a strictness annotation (bang) on an unlifted type is redudant as unlifted values are strict by definition
 severity: warning
 flag: -Wredundant-strictness-flags
-introduced: GHC 9.6.1
+introduced: 9.6.1
 ---
 
 A strictness annotation (also called a bang: `!`) can be used to denote that a value should not be evaluated lazily.

--- a/message-index/messages/GHC-87491/index.md
+++ b/message-index/messages/GHC-87491/index.md
@@ -2,7 +2,7 @@
 title: Found 'qualified' after the module
 summary: qualified after the module requires the ImportQualifiedPost extension.
 severity: error
-introduced: 8.10.1
+introduced: 9.6.1
 ---
 
 The [`ImportQualifiedPost extension`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/import_qualified_post.html),


### PR DESCRIPTION
The `introduced` field indicates the first GHC version which emits the error **code**, not the first GHC version which emits the error. 