### PR TITLE
Fix issue #444 (hakyll runs out of file handles)

### DIFF
--- a/message-index/message-index.cabal
+++ b/message-index/message-index.cabal
@@ -6,7 +6,7 @@ cabal-version:      2.0
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll ^>= 4.16.0.0
+                  , hakyll ^>= 4.16.1.0
                   , commonmark >= 0.2.2
                   , filepath ^>= 1.4
                   , microlens ^>= 0.4.12


### PR DESCRIPTION
Fixes #444
On systems which don't provide enough file handles to processes, building the site with hakyll can fail since hakyll holds on to too many file handles at the same time.
This commit bumps the minimum requirement on hakyll to version 4.16.1.0, which fixes the problem.

I am just running this through CI for the moment, to see if it also works there.