### PR TITLE
Revert to using hakyll 4.16.0.0

### DIFF
--- a/message-index/message-index.cabal
+++ b/message-index/message-index.cabal
@@ -6,7 +6,7 @@ cabal-version:      2.0
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll ^>= 4.16.1.0
+                  , hakyll == 4.16.0.0
                   , commonmark >= 0.2.2
                   , filepath ^>= 1.4
                   , microlens ^>= 0.4.12
@@ -15,5 +15,4 @@ executable site
                   , pandoc-types ^>= 1.22 || ^>= 1.23
                   , containers ^>= 0.6
                   , text ^>= 1.2 || ^>= 2.0
-  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010

--- a/message-index/stack.yaml
+++ b/message-index/stack.yaml
@@ -1,3 +1,3 @@
 resolver: lts-19.10
 extra-deps:
-  - hakyll-4.16.1.0
+  - hakyll-4.16.0.0

--- a/message-index/stack.yaml.lock
+++ b/message-index/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: hakyll-4.16.1.0@sha256:2f5984ec2f0bfc066279f61747839c149f90fbc0d4655c3cf51acda2cf7111b6,9845
+    hackage: hakyll-4.16.0.0@sha256:68426098d96f8bd17216c0f53a34856dc0e6386c7405f38afbd891f3fa878ed3,10198
     pantry-tree:
-      sha256: 8bcd5b6e99b7e461508c39e7c71dfe7e90d0dae2620b98464d697df5ed2fda23
-      size: 9185
+      sha256: 59ace0aab85d131b505ad85eab16d532a99cdd041b2328c28a153921768340aa
+      size: 9052
   original:
-    hackage: hakyll-4.16.1.0
+    hackage: hakyll-4.16.0.0
 snapshots:
 - completed:
     sha256: 005f204647467d65c4ab549a5ca35d54b3d90a84a99a4ffc5d421a4018854fe2


### PR DESCRIPTION
We discovered a bug in the new scheduler for hakyll: https://github.com/jaspervdj/hakyll/issues/1000
For this reason, we are reverting back to hakyll
version 4.16.0.0 for the moment and disable the threaded runtime.

See #459 and #444