### PR TITLE
Add example to GHC-88464

### DIFF
--- a/message-index/messages/GHC-88464/example2/after/ForgotImport.hs
+++ b/message-index/messages/GHC-88464/example2/after/ForgotImport.hs
@@ -1,0 +1,6 @@
+module ForgotImport where
+
+import Data.List (sort)
+
+top10 :: [Int] -> [Int]
+top10 = take 10 . sort

--- a/message-index/messages/GHC-88464/example2/before/ForgotImport.hs
+++ b/message-index/messages/GHC-88464/example2/before/ForgotImport.hs
@@ -1,0 +1,4 @@
+module ForgotImport where
+
+top10 :: [Int] -> [Int]
+top10 = take 10 . sort

--- a/message-index/messages/GHC-88464/example2/index.md
+++ b/message-index/messages/GHC-88464/example2/index.md
@@ -1,0 +1,17 @@
+---
+title: Forgetting an import declaration
+---
+
+## Error Message
+
+```
+ForgotImport.hs:4:19: error: [GHC-88464]
+    Variable not in scope: sort :: [Int] -> [Int]
+    Suggested fix: Perhaps use ‘sqrt’ (imported from Prelude)
+  |
+4 | top10 = take 10 . sort
+  |                   ^^^^
+```
+
+## Description
+In this example, the programmer forgot to import the `sort` function from the `Data.List` module. The updated version adds the appropriate import declaration.

--- a/message-index/messages/GHC-88464/index.md
+++ b/message-index/messages/GHC-88464/index.md
@@ -9,9 +9,14 @@ This error means that a variable name used in a program can't be matched up with
 
 In Haskell, every variable comes into existence at a specific location. Examples include function argument names, local definitions with `let`, and module-level definitions. Creating a new name like this is called _binding_ it, and the area of the program that can refer to the new name is called its _scope_. The message means that the provided name is not available for reference right where it is referred to.
 
+A common situation where this error occurs is when the programmer forgets to import some name from a module. In that case, the solution is to add the missing import declaration.
+
 ## Example error text
 
 ```
 error: [GHC-88464] Variable not in scope: x
 ```
 
+```
+error: [GHC-88464] Variable not in scope: sort :: [Int] -> [Int]
+```


### PR DESCRIPTION
Adds an example to GHC-88464 (Variable not in scope), since that error can also occur when the programmer forgot an import declaration.