### PR TITLE
Fix #469 by removing duplicated routes

### DIFF
--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -48,7 +48,6 @@ main = hakyll $ do
   for_ exampleExtensions $ \ext -> do
     match (fromGlob $ "messages/*/*/**." <> ext) $
       version "raw" $ do
-        route idRoute
         compile getResourceBody
 
     match (fromGlob $ "messages/*/*/**." <> ext) $ do
@@ -130,7 +129,6 @@ main = hakyll $ do
 
   match "index.html" $
     version "nav" $ do
-      route idRoute
       compile getResourceBody
 
   match "index.html" $ do


### PR DESCRIPTION
Fixes #469 

We had multiple output routes which mapped the same file to the same output twice:

- The file `index.html` was mapped twice via `idRoute` to the output `index.html`
- The example `*.hs` files were mapped twice via `idRoute` to the output `*.hs` files.