### PR TITLE
Document GHC-61689; Add examples to GHC-88464 and GHC-76037

### DIFF
--- a/message-index/messages/GHC-61689/example1/after/A.hs
+++ b/message-index/messages/GHC-61689/example1/after/A.hs
@@ -1,0 +1,7 @@
+module A (one) where
+
+one :: ()
+one = ()
+
+two :: ()
+two = ()

--- a/message-index/messages/GHC-61689/example1/after/SymbolNotExported.hs
+++ b/message-index/messages/GHC-61689/example1/after/SymbolNotExported.hs
@@ -1,0 +1,3 @@
+module SymbolNotExported where
+
+import A (one)

--- a/message-index/messages/GHC-61689/example1/before/A.hs
+++ b/message-index/messages/GHC-61689/example1/before/A.hs
@@ -1,0 +1,7 @@
+module A (one) where
+
+one :: ()
+one = ()
+
+two :: ()
+two = ()

--- a/message-index/messages/GHC-61689/example1/before/SymbolNotExported.hs
+++ b/message-index/messages/GHC-61689/example1/before/SymbolNotExported.hs
@@ -1,0 +1,3 @@
+module SymbolNotExported where
+
+import A (one, two)

--- a/message-index/messages/GHC-61689/example1/index.md
+++ b/message-index/messages/GHC-61689/example1/index.md
@@ -1,0 +1,18 @@
+---
+title: Importing an unexported symbol.
+---
+
+## Message
+```
+SymbolNotExported.hs:3:16: error: [GHC-61689]
+    Module ‘A’ does not export ‘two’.
+  |
+3 | import A (one, two)
+  |                ^^^
+```
+
+## Explanation
+
+The module `SymbolNotExported` imports the symbol `two` even though `A` does not export it.
+
+The fix is to remove the bad import.

--- a/message-index/messages/GHC-61689/example2/after/A.hs
+++ b/message-index/messages/GHC-61689/example2/after/A.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module A (Foo (..)) where
+
+data Foo = MkFoo { fint :: Int, fchar :: Char }

--- a/message-index/messages/GHC-61689/example2/after/NoFieldSelectors.hs
+++ b/message-index/messages/GHC-61689/example2/after/NoFieldSelectors.hs
@@ -1,0 +1,3 @@
+module NoFieldSelectors where
+
+import A (Foo (MkFoo, fint))

--- a/message-index/messages/GHC-61689/example2/before/A.hs
+++ b/message-index/messages/GHC-61689/example2/before/A.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module A (Foo (..)) where
+
+data Foo = MkFoo { fint :: Int, fchar :: Char }

--- a/message-index/messages/GHC-61689/example2/before/NoFieldSelectors.hs
+++ b/message-index/messages/GHC-61689/example2/before/NoFieldSelectors.hs
@@ -1,0 +1,3 @@
+module NoFieldSelectors where
+
+import A (Foo (MkFoo), fint)

--- a/message-index/messages/GHC-61689/example2/index.md
+++ b/message-index/messages/GHC-61689/example2/index.md
@@ -1,0 +1,33 @@
+---
+title: Importing a field selector that has been disabled with NoFieldSelectors.
+---
+
+## Message
+```
+NoFieldSelectors.hs:3:24: error: [GHC-61689]
+    Module ‘A’ does not export ‘fint’.
+    Suggested fix:
+      Notice that ‘fint’ is a field selector belonging to the type ‘A.Foo’
+      that has been suppressed by NoFieldSelectors.
+  |
+3 | import A (Foo (MkFoo), fint)
+  |                        ^^^^
+```
+
+## Explanation
+
+With `FieldSelectors` (the default), field selectors are exported such that the following two imports are equivalent:
+
+```haskell
+
+import A (Foo (MkFoo, fint))
+import A (Foo (MkFoo), fint)
+```
+
+With `NoFieldSelectors` at the _definition site_ (`A.hs`), the second example is always an error:
+
+```haskell
+import A (Foo (MkFoo), fint)
+```
+
+The fix is to move the selector import to the type or remove it altogether.

--- a/message-index/messages/GHC-61689/index.md
+++ b/message-index/messages/GHC-61689/index.md
@@ -1,0 +1,8 @@
+---
+title: Bad import not exported
+summary: Module does not export the imported symbol.
+severity: error
+introduced: 9.8.1
+---
+
+This error is triggered when importing a symbol that the module does not export.

--- a/message-index/messages/GHC-76037/example4/after/NoFieldSelectorsExport.hs
+++ b/message-index/messages/GHC-76037/example4/after/NoFieldSelectorsExport.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module NoFieldSelectorsExport (T (foo)) where
+
+data T = MkT { foo :: T }

--- a/message-index/messages/GHC-76037/example4/before/NoFieldSelectorsExport.hs
+++ b/message-index/messages/GHC-76037/example4/before/NoFieldSelectorsExport.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module NoFieldSelectorsExport (T, foo) where
+
+data T = MkT { foo :: T }

--- a/message-index/messages/GHC-76037/example4/index.md
+++ b/message-index/messages/GHC-76037/example4/index.md
@@ -1,0 +1,20 @@
+---
+title: Field selector exported with NoFieldSelectors
+---
+
+## Error Message
+
+```
+NoFieldSelectorsExport.hs:3:35: error: [GHC-76037]
+    Not in scope: ‘foo’
+    Suggested fix:
+      Notice that ‘foo’ is a field selector belonging to the type ‘T’
+      that has been suppressed by NoFieldSelectors.
+  |
+3 | module NoFieldSelectorsExport (T, foo) where
+  |                                   ^^^
+```
+
+## Explanation
+
+The field selector `foo` has been disabled via `NoFieldSelectors`, therefore it cannot be a top-level export. The fix is to export it as part of its type `T` (consequently it can be imported for e.g. record creation or updates).

--- a/message-index/messages/GHC-88464/example3/after/A.hs
+++ b/message-index/messages/GHC-88464/example3/after/A.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module A (Foo (..)) where
+
+data Foo = MkFoo { fint :: Int, fchar :: Char }

--- a/message-index/messages/GHC-88464/example3/after/Example3.hs
+++ b/message-index/messages/GHC-88464/example3/after/Example3.hs
@@ -1,0 +1,18 @@
+module Example3 where
+
+import A (Foo (MkFoo, fint, fchar))
+
+getFooInt :: Foo -> Int
+getFooInt (MkFoo i _) = i -- this is fine
+
+-- Creation and updates below are fine
+
+mkFoo :: Foo
+mkFoo =
+  MkFoo
+    { fint = 0,
+      fchar = 'a'
+    }
+
+setFooInt :: Foo -> Int -> Foo
+setFooInt f x = f { fint = x }

--- a/message-index/messages/GHC-88464/example3/before/A.hs
+++ b/message-index/messages/GHC-88464/example3/before/A.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module A (Foo (..)) where
+
+data Foo = MkFoo { fint :: Int, fchar :: Char }

--- a/message-index/messages/GHC-88464/example3/before/Example3.hs
+++ b/message-index/messages/GHC-88464/example3/before/Example3.hs
@@ -1,0 +1,18 @@
+module Example3 where
+
+import A (Foo (MkFoo, fint, fchar))
+
+getFooInt :: Foo -> Int
+getFooInt = fint -- this is the problem
+
+-- Creation and updates below are fine
+
+mkFoo :: Foo
+mkFoo =
+  MkFoo
+    { fint = 0,
+      fchar = 'a'
+    }
+
+setFooInt :: Foo -> Int -> Foo
+setFooInt f x = f { fint = x }

--- a/message-index/messages/GHC-88464/example3/index.md
+++ b/message-index/messages/GHC-88464/example3/index.md
@@ -1,0 +1,22 @@
+---
+title: Attempted to use a field selector disabled with NoFieldSelectors
+---
+
+## Error Message
+
+```
+Example3.hs:14:13: error: [GHC-88464]
+    Variable not in scope: fint :: Foo -> Int
+    Suggested fix:
+      Notice that ‘fint’ is a field selector belonging to the type ‘Foo’
+      that has been suppressed by NoFieldSelectors.
+   |
+14 | getFooInt = fint
+   |             ^^^^
+```
+
+## Description
+
+This example attempts to use the field selector `fint`, despite it being disabled at the definition site (`A.hs`) with `NoFieldSelectors`. This fix is to use pattern matching instead.
+
+Notice that record creation and updates still work with `NoFieldSelectors`.


### PR DESCRIPTION
Hello!

I recently ran into the error like

```
E2NoFieldSelectors.hs:11:24: error: [GHC-61689]
    Module ‘A’ does not export ‘fint’.
    Suggested fix:
      Notice that ‘fint’ is a field selector belonging to the type ‘A.Foo’
      that has been suppressed by NoFieldSelectors.
   |
11 | import A (Foo (MkFoo), fint)
   |                        ^^^^
```

And I found the various nuances confusing enough that I thought it merited a description here. It turns out there are multiple errors that can trigger this message.

### GHC-61689 (New)

This is a new error introduced in GHC 9.8.1 for importing a an unexported symbol.

```haskell
-- GHC-61689, fint is a field selector disabled with NoFieldSelectors, always an error
import A (Foo (MkFoo), fint)
```

### GHC-88464

This was previously documented in other cases, but it can also trigger the `NoFieldSelectors` message in the right circumstances.

```haskell
-- GHC-88464, error if fint is used as a selector, OK otherwise
import A (Foo (MkFoo, fint))

getFooInt :: Foo -> Int
getFooInt = fint -- this is the problem
```

### GHC-76037

Similar to GHC-61689, though it involves the _export_, not the import.

```haskell

{-# LANGUAGE NoFieldSelectors #-}

-- GHC-76037, error if foo is exported at the top-level rather than part of T.
module NoFieldSelectorsExport (T, foo) where

data T = MkT { foo :: T }
```

I have this in the same PR as they are all related, but please let me know if they should be split up, or if there should be issues created. Thanks!