### PR TITLE
Add documentation for GHC-21926

### DIFF
--- a/message-index/messages/GHC-21926/index.md
+++ b/message-index/messages/GHC-21926/index.md
@@ -6,6 +6,6 @@ introduced: 9.6.1
 extension: PackageImports
 ---
 
-Version number or non-alphanumeric character in the package. Alphanumeric characters are letters and numbers, as defined by `Data.Char.isAlphaNum`.
+Version number or non-alphanumeric character in the package. Each of dash-separated components of package name must consist of alphanumeric characters (as defined by `Data.Char.isAlphaNum`), at least one of which is not a digit.
 Note that you will also see this error if the package name consists only of digits.
 The package name in this case refers to the one mentioned in an import when using the `PackageImports` language extension.

--- a/message-index/messages/GHC-21926/index.md
+++ b/message-index/messages/GHC-21926/index.md
@@ -5,5 +5,5 @@ severity: error
 introduced: 9.6.1
 ---
 
-Version number or non-alphanumeric character in package name.
+Version number or non-alphanumeric character in package name. Alphanumeric characters are letters and numbers, as defined by `Data.Char.isAlphaNum`.
 The package name in this case refers to the package specified with imports after enabling the `PackageImports` language extension.

--- a/message-index/messages/GHC-21926/index.md
+++ b/message-index/messages/GHC-21926/index.md
@@ -1,0 +1,9 @@
+---
+title: Version number or non-alphanumeric character in package name
+summary: Package imports may only consist of alphanumeric characters, and must omit the version
+severity: error
+introduced: 9.6.1
+---
+
+Version number or non-alphanumeric character in package name.
+The package name in this case refers to the package specified with imports after enabling the `PackageImports` language extension.

--- a/message-index/messages/GHC-21926/index.md
+++ b/message-index/messages/GHC-21926/index.md
@@ -1,8 +1,9 @@
 ---
 title: Version number or non-alphanumeric character in package name
-summary: Package imports may only consist of alphanumeric characters, and must omit the version
+summary: Package imports may only consist of alphanumeric characters, and must omit the version.
 severity: error
 introduced: 9.6.1
+extension: PackageImports
 ---
 
 Version number or non-alphanumeric character in the package. Alphanumeric characters are letters and numbers, as defined by `Data.Char.isAlphaNum`.

--- a/message-index/messages/GHC-21926/index.md
+++ b/message-index/messages/GHC-21926/index.md
@@ -5,5 +5,6 @@ severity: error
 introduced: 9.6.1
 ---
 
-Version number or non-alphanumeric character in package name. Alphanumeric characters are letters and numbers, as defined by `Data.Char.isAlphaNum`.
-The package name in this case refers to the package specified with imports after enabling the `PackageImports` language extension.
+Version number or non-alphanumeric character in the package. Alphanumeric characters are letters and numbers, as defined by `Data.Char.isAlphaNum`.
+Note that you will also see this error if the package name consists only of digits.
+The package name in this case refers to the one mentioned in an import when using the `PackageImports` language extension.

--- a/message-index/messages/GHC-21926/non-alphanumeric-in-package/after/Non-alphanumeric-in-package.hs
+++ b/message-index/messages/GHC-21926/non-alphanumeric-in-package/after/Non-alphanumeric-in-package.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
+module NonAlphanumericCharacterNameInPackage where
+
+import "some-existing-package" Package.With.Non.Alphanumeric.Characters

--- a/message-index/messages/GHC-21926/non-alphanumeric-in-package/before/Non-alphanumeric-in-package.hs
+++ b/message-index/messages/GHC-21926/non-alphanumeric-in-package/before/Non-alphanumeric-in-package.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
+module NonAlphanumericCharacterNameInPackage where
+
+import "&*$^%!@()" Package.With.Non.Alphanumeric.Characters

--- a/message-index/messages/GHC-21926/non-alphanumeric-in-package/index.md
+++ b/message-index/messages/GHC-21926/non-alphanumeric-in-package/index.md
@@ -1,0 +1,3 @@
+---
+title: Non-alphanumeric characters in the package name
+---

--- a/message-index/messages/GHC-21926/version-number-in-package/after/Version-name-in-package.hs
+++ b/message-index/messages/GHC-21926/version-number-in-package/after/Version-name-in-package.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
+module VersionNameInPackage where
+
+import "some-package" Package.With.Version

--- a/message-index/messages/GHC-21926/version-number-in-package/before/Version-name-in-package.hs
+++ b/message-index/messages/GHC-21926/version-number-in-package/before/Version-name-in-package.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
+module VersionNameInPackage where
+
+import "some-package-0.1.2.3" Package.With.Version

--- a/message-index/messages/GHC-21926/version-number-in-package/index.md
+++ b/message-index/messages/GHC-21926/version-number-in-package/index.md
@@ -1,0 +1,3 @@
+---
+title: Version number in package
+---

--- a/message-index/messages/GHC-21926/version-number-in-package/index.md
+++ b/message-index/messages/GHC-21926/version-number-in-package/index.md
@@ -1,3 +1,3 @@
 ---
-title: Version number in package
+title: Version number in package name
 ---


### PR DESCRIPTION
This is the card I drew during ZuriHac! :card_index: 

This is quite a simple parser error, which can be hit when `PackageImports` is enabled. The error itself is quite clear already: don't put version numbers and non-alphanumeric characters in a package import.

I'm not sure how one would get into the non-alphanumeric character situation (besides an honest typo), but the version one is quite a fair mistake to make. 