### PR TITLE
Remove noindex meta tag from html header

### DIFF
--- a/message-index/templates/default.html
+++ b/message-index/templates/default.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
   <title>$title$ — Haskell Error Index</title>
   <link rel="stylesheet" href="/css/highlight.css">
   <script src="/js/highlight.min.js"></script>


### PR DESCRIPTION
Fixes #537 by removing the `noindex` meta tag in the html header.