### PR TITLE
Document GHC-08838

### DIFF
--- a/message-index/messages/GHC-08838/WrongDoBind/after/WrongDoBind.hs
+++ b/message-index/messages/GHC-08838/WrongDoBind/after/WrongDoBind.hs
@@ -1,0 +1,4 @@
+module WrongDoBind where
+
+doubleReturn :: forall m. Monad m => m Int
+doubleReturn = return 10

--- a/message-index/messages/GHC-08838/WrongDoBind/before/WrongDoBind.hs
+++ b/message-index/messages/GHC-08838/WrongDoBind/before/WrongDoBind.hs
@@ -1,0 +1,6 @@
+module WrongDoBind where
+
+doubleReturn :: forall m. Monad m => m Int
+doubleReturn = do
+  return (return 10 :: m Int)
+  return 10

--- a/message-index/messages/GHC-08838/WrongDoBind/index.md
+++ b/message-index/messages/GHC-08838/WrongDoBind/index.md
@@ -1,0 +1,16 @@
+
+---
+title: Double return
+---
+
+In this example, there is a nested return whose result is not bound to a variable. Therefore the computation `return 10` is not used and can be removed.
+
+```
+messages/GHC-08838/WrongDoBind/before/WrongDoBind.hs:5:4: warning: [GHC-08838] [-Wwrong-do-bind]
+    A do-notation statement discarded a result of type ‘m Int’
+    Suggested fix:
+      Suppress this warning by saying ‘_ <- return (return 10 :: m Int)’
+  |
+5 |    return (return 10 :: m Int)
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/message-index/messages/GHC-08838/index.md
+++ b/message-index/messages/GHC-08838/index.md
@@ -2,7 +2,7 @@
 title: Wrong do bind
 summary: Returning a monadic computation in a do block and not binding it will not run it
 severity: warning
-introduced: 9.4.1
+introduced: 9.6.1
 ---
 When using a monadic computation in a do block one should either run it 
 directly or bind the result of the computation to a variable. If neither 

--- a/message-index/messages/GHC-08838/index.md
+++ b/message-index/messages/GHC-08838/index.md
@@ -1,0 +1,9 @@
+---
+title: Wrong do bind
+summary: Returning a monadic computation in a do block and not binding it will not run it
+severity: warning
+introduced: 9.4.1
+---
+When using a monadic computation in a do block one should either run it 
+directly or bind the result of the computation to a variable. If neither 
+is done the monadic computation is never run and can be removed.


### PR DESCRIPTION
We need a better example here. It seems to be this warning only occurs with nested returns. I tried
```haskell
f = do
  return (putStrLn "text")
  return ()
```
which didn't produce that warning