### PR TITLE
GHC-58481 overloaded labels example

### DIFF
--- a/message-index/messages/GHC-58481/example5/after/Label.hs
+++ b/message-index/messages/GHC-58481/example5/after/Label.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+module Label where
+
+import GHC.OverloadedLabels (IsLabel)
+
+foo :: (IsLabel "foo" ()) => ()
+foo = #foo

--- a/message-index/messages/GHC-58481/example5/before/Label.hs
+++ b/message-index/messages/GHC-58481/example5/before/Label.hs
@@ -1,0 +1,6 @@
+module Label where
+
+import GHC.OverloadedLabels (IsLabel)
+
+foo :: (IsLabel "foo" ()) => ()
+foo = #foo

--- a/message-index/messages/GHC-58481/example5/index.md
+++ b/message-index/messages/GHC-58481/example5/index.md
@@ -1,0 +1,12 @@
+---
+title: Use of overloaded labels without enabled language extension
+---
+
+In this examplem the user attempted to use an overloaded label without enabling the `OverloadedLabels` extension, which leads to this generic parsing error. [Overloaded Labels](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/overloaded_labels.html#extension-OverloadedLabels) assign a special meaning to the `#` character in front of an identifier, or (since GHC 9.6) any non-empty double-quoted string.
+
+```
+messages/GHC-58481/example5/before/Label.hs:4:7: error: [GHC-58481] parse error on input ‘#’
+  |
+4 | foo = #foo
+  |       ^
+```

--- a/message-index/messages/GHC-58481/example5/index.md
+++ b/message-index/messages/GHC-58481/example5/index.md
@@ -2,7 +2,7 @@
 title: Use of overloaded labels without enabled language extension
 ---
 
-In this examplem the user attempted to use an overloaded label without enabling the `OverloadedLabels` extension, which leads to this generic parsing error. [Overloaded Labels](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/overloaded_labels.html#extension-OverloadedLabels) assign a special meaning to the `#` character in front of an identifier, or (since GHC 9.6) any non-empty double-quoted string.
+In this example the user attempted to use an overloaded label without enabling the `OverloadedLabels` extension, which leads to this generic parsing error. [Overloaded Labels](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/overloaded_labels.html#extension-OverloadedLabels) assign a special meaning to the `#` character in front of an identifier, or (since GHC 9.6) any non-empty double-quoted string.
 
 ```
 messages/GHC-58481/example5/before/Label.hs:4:7: error: [GHC-58481] parse error on input ‘#’

--- a/message-index/messages/GHC-58481/index.md
+++ b/message-index/messages/GHC-58481/index.md
@@ -12,4 +12,4 @@ However if the error is not separately defined there, a problem with parsing is 
 
 There may be many different reasons why the error `GHC-58481` was emitted, ranging from incorrect syntax that requires additional language extensions, to an expression mistakenly put in the same line as another.
 
-Below are some examples of code that generate this generic parsing error. Please be encouraged to report more or contribute via [error-messages github](https://github.com/haskell/error-messages).
+Below are some examples of code that generate this generic parsing error. Please be encouraged to report more or contribute via [error-message-index github](https://github.com/haskell/error-message-index).


### PR DESCRIPTION
The absence of Overloaded Labels can cause confusing parse errors because `#` is lexed as an operator, which then confuses the parser. Try to help the situation by adding an example.

Note: I had to bypass pre-commit hooks when committing the example, because ormolu wanted to format the "before" example and failed because it is designed not to parse. Is there a way to exclude `message-index/messages/GHC-58481/example5/before/Label.hs` from autoformatting?