### PR TITLE
Add canonical links to improve SEO

### DIFF
--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -116,7 +116,7 @@ main = hakyll $ do
                 defaultContext
               ]
           )
-        >>= loadAndApplyTemplate "templates/default.html" (bread <> messageTitleField <> defaultContext)
+        >>= loadAndApplyTemplate "templates/default.html" (indexlessUrlField "url" <> bread <> messageTitleField <> defaultContext)
         >>= relativizeUrls
 
   match "messages/index.md" $ do

--- a/message-index/templates/default.html
+++ b/message-index/templates/default.html
@@ -10,6 +10,7 @@
   <script src="/js/highlight.min.js"></script>
   <link rel="stylesheet" href="/css/default.css" />
   <link rel="stylesheet" href="/css/theme.css" />
+  <link rel="canonical" href="$url$" />
 </head>
 
 <body>


### PR DESCRIPTION
Another item to tackle #537, as suggested by Google Search Console.